### PR TITLE
Correct distinction between diagnostic messages (via TidyMessageCallBack) and the report (via TidyErrorSink)

### DIFF
--- a/src/Document.cpp
+++ b/src/Document.cpp
@@ -4,7 +4,7 @@ using namespace System::Runtime::InteropServices;
 
 #include "Document.hpp"
 #include "InputSource.hpp"
-#include "OutputSink.hpp"
+#include "StreamSink.hpp"
 #include "TidyException.hpp"
 #include "Tidy.hpp"
 
@@ -14,6 +14,15 @@ namespace TidyHtml5Dotnet
 	{
 		_tidyDoc = tidyCreate();
 
+		// Create delegate and keep it alive by storing in member variable
+		_tidyMessageDelegate = gcnew TidyMessageDelegate(this, &Document::OnReceiveTidyMessage);
+		auto feedbackPointer = Marshal::GetFunctionPointerForDelegate(_tidyMessageDelegate).ToPointer();
+		if (tidySetMessageCallback(_tidyDoc, static_cast<TidyMessageCallback>(feedbackPointer)) == no)
+		{
+			throw gcnew InvalidOperationException("Failed to set tidy message callback");
+		}
+
+		// Options
 		_cleanupOptions = gcnew TidyHtml5Dotnet::CleanupOptions(_tidyDoc);
 		_diagnosticOptions = gcnew TidyHtml5Dotnet::DiagnosticOptions(_tidyDoc);
 		_displayOptions = gcnew TidyHtml5Dotnet::DisplayOptions(_tidyDoc);
@@ -30,7 +39,7 @@ namespace TidyHtml5Dotnet
 	Document::Document(String^ htmlString) : Document()
 	{
 		ArgumentNullException::ThrowIfNullOrWhiteSpace(htmlString, "htmlString");
-				
+
 		_contentString = Conversions::StringToCharArray(htmlString);
 		_inputLength = htmlString->Length;
 	};
@@ -56,7 +65,7 @@ namespace TidyHtml5Dotnet
 	Document^ Document::FromStream(Stream^ stream)
 	{
 		return gcnew Document(stream);
-	}	
+	}
 
 	Document^ Document::FromFile(String^ filePath)
 	{
@@ -68,12 +77,44 @@ namespace TidyHtml5Dotnet
 		return gcnew Document(gcnew FileStream(filePath, FileMode::Open));
 	}
 
+	Document^ Document::WithReportStream(Stream^ stream)
+	{
+		ArgumentNullException::ThrowIfNull(stream, "stream");
+
+		if (!stream->CanWrite)
+			throw gcnew ArgumentException("Stream must be writable.");
+
+		_reportStreamSink = gcnew StreamSink(stream);
+
+		int result = tidySetErrorSink(_tidyDoc, _reportStreamSink->TidyOutSink);
+		if (result != 0)
+			throw gcnew InvalidOperationException("Failed to set error stream sink");
+
+		return this;
+	}
+
+	Document^ Document::WithReportFile(String^ filePath)
+	{
+		ArgumentNullException::ThrowIfNullOrWhiteSpace(filePath, "filePath");
+
+		FILE* f = tidySetErrorFile(_tidyDoc, Conversions::StringToCharArray(filePath));
+
+		if (f == nullptr)
+		{
+			throw gcnew IOException(
+				String::Format("Failed to open error file '{0}'.", filePath));
+		}
+
+		return this;
+	}
+
 	Document::~Document()
 	{
 		if (_disposed) return;
 
 		delete _inputSource;
-		_feedbackMessageDelegate = nullptr;  // Release delegate reference
+		delete _reportStreamSink;
+		_tidyMessageDelegate = nullptr;  // Release delegate reference
 
 		this->!Document();
 		_disposed = true;
@@ -81,7 +122,7 @@ namespace TidyHtml5Dotnet
 
 	Document::!Document()
 	{
-		//Free unmanaged objects here
+		//Free unmanaged objects
 		Conversions::FreeCharArray(_contentString);
 		tidyRelease(_tidyDoc);
 	}
@@ -90,53 +131,33 @@ namespace TidyHtml5Dotnet
 	/// Callback used by tidylib to return feedback messages
 	/// </summary>
 	/// <param name="tmessage">tidylib warning or error message</param>
-	/// <returns>yes or no, indicating if tidylib should log to standard output or not</returns>
-	Bool Document::FeedbackMessageCallback(TidyMessage tmessage)
+	/// <returns>yes or no, indicating if tidylib should log to the report stream or report file or not</returns>
+	Bool Document::OnReceiveTidyMessage(TidyMessage tmessage)
 	{
-		if (FeedbackMessagesCallback != nullptr)
+		auto feedbackMessage = gcnew FeedbackMessage(tmessage);
+
+		IncludeInReport includeInReport = IncludeInReport::Yes;
+
+		if (OnReceiveDiagnosticMessage != nullptr)
 		{
-			auto feedbackMessage = gcnew FeedbackMessage(tmessage);
-			FeedbackMessagesCallback(feedbackMessage);
-			return no;
+			includeInReport = OnReceiveDiagnosticMessage(feedbackMessage);
 		}
-		return yes;
+
+		if (includeInReport == IncludeInReport::Yes)
+		{
+			_diagnosticMessages->Add(feedbackMessage);
+			return yes;
+		}
+
+		return no;
 	}
 
-	void Document::FeedbackMessagesCallback::set(Action<FeedbackMessage^>^ feedbackMessageHandler)
+	/// @brief Loads document config options from config file
+	/// @param filePath Path to the config file
+	/// @param encoding Encoding of the config file. If unspecified, assumes Ascii
+	/// @return Error code indicating success or failure reading the file and setting the options
+	DocumentStatuses Document::LoadConfig(String^ filePath, Nullable<Encodings> encoding)
 	{
-	    Bool succes = no;
-
-	    if (feedbackMessageHandler)
-	    {
-	        // Create delegate and keep it alive by storing in member variable
-			_feedbackMessageDelegate = gcnew FeedbackMessageDelegate(this, &Document::FeedbackMessageCallback);
-	        auto feedbackPointer = Marshal::GetFunctionPointerForDelegate(_feedbackMessageDelegate).ToPointer();
-	        succes = tidySetMessageCallback(_tidyDoc, static_cast<TidyMessageCallback>(feedbackPointer));
-	    }
-	    else
-	    {
-	        succes = tidySetMessageCallback(_tidyDoc, nullptr);
-			_feedbackMessageDelegate = nullptr;  // Allow GC to collect when unregistered
-	    }
-
-	    if (succes == no)
-	        throw gcnew InvalidOperationException("Failed to set feedback message callback");
-
-	    _feedbackMessagesCallback = feedbackMessageHandler;
-	}
-
-	Action<FeedbackMessage^>^ Document::FeedbackMessagesCallback::get()
-	{
-		return _feedbackMessagesCallback;
-	}
-
-    /// @brief Loads document config options from config file
-    /// @param filePath Path to the config file
-    /// @param encoding Encoding of the config file. If unspecified, assumes Ascii
-    /// @return Error code indicating success or failure reading the file and setting the options
-    DocumentStatuses Document::LoadConfig(String ^ filePath, Nullable<Encodings> encoding)
-    {
-
 		if (!encoding.HasValue) { encoding = Encodings::Ascii; }
 		String^ encodingName = Enum::GetName(Encodings::typeid, encoding);
 
@@ -149,13 +170,13 @@ namespace TidyHtml5Dotnet
 		Conversions::FreeCharArray(encodingC);
 
 		return static_cast<DocumentStatuses>(result);
-    }
+	}
 
-    /// <summary>
-    /// Parses input markup, and executes configured cleanup and repair operations.
-    /// </summary>
-    /// <returns>See Tidy error code convention (DocumentStatuses)</returns>
-    DocumentStatuses Document::CleanAndRepair()
+	/// <summary>
+	/// Parses input markup, and executes configured cleanup and repair operations.
+	/// </summary>
+	/// <returns>See Tidy error code convention (DocumentStatuses)</returns>
+	DocumentStatuses Document::CleanAndRepair()
 	{
 		int parseResult = 0;
 		if (this->_contentString != nullptr)
@@ -195,17 +216,17 @@ namespace TidyHtml5Dotnet
 		return static_cast<DocumentStatuses>(repairResult);
 	}
 
-    DocumentStatuses Document::ReportDocType()
-    {
+	DocumentStatuses Document::ReportDocType()
+	{
 		auto result = tidyReportDoctype(_tidyDoc);
-        return static_cast<DocumentStatuses>(result);
-    }
+		return static_cast<DocumentStatuses>(result);
+	}
 
-    DocumentStatuses Document::RunDiagnostics()
-    {
+	DocumentStatuses Document::RunDiagnostics()
+	{
 		auto result = tidyRunDiagnostics(_tidyDoc);
-        return static_cast<DocumentStatuses>(result);
-    }
+		return static_cast<DocumentStatuses>(result);
+	}
 
 	void Document::ErrorSummary()
 	{
@@ -217,8 +238,8 @@ namespace TidyHtml5Dotnet
 		tidyGeneralInfo(_tidyDoc);
 	}
 
-    String^ Document::ToString()
-    {
+	String^ Document::ToString()
+	{
 		int status = 0;
 		tmbstr buffer = nullptr;
 		uint outputLength = _inputLength * 2u; // Foresee enough initial room for cleaned output
@@ -226,7 +247,7 @@ namespace TidyHtml5Dotnet
 		if (_inputLength > UINT_MAX / 2)
 			return String::Empty; // Prevent overflow
 
-		auto previousEncoding = _encodingOptions->OutputCharacterEncoding;		
+		auto previousEncoding = _encodingOptions->OutputCharacterEncoding;
 
 		// TODO: slow buffer increment +1. What if doc could give required length before hand
 		do {
@@ -237,38 +258,38 @@ namespace TidyHtml5Dotnet
 
 		buffer[outputLength] = '\0';
 		auto output = gcnew String(buffer);
-		delete [] buffer;
+		delete[] buffer;
 
 		_encodingOptions->OutputCharacterEncoding = previousEncoding;
 
 		return output;
-    }
+	}
 
-    DocumentStatuses Document::ToStream(Stream ^ stream)
-    {
+	DocumentStatuses Document::ToStream(Stream^ stream)
+	{
 		ArgumentNullException::ThrowIfNull(stream, "stream");
 
 		if (!stream->CanWrite)
-			throw gcnew ArgumentException("Stream must be writeable.");		
+			throw gcnew ArgumentException("Stream must be writeable.");
 
-		auto result = tidySaveSink(_tidyDoc, (gcnew OutputSink(stream))->TidyOutSink);
+		auto result = tidySaveSink(_tidyDoc, (gcnew StreamSink(stream))->TidyOutSink);
 		return static_cast<DocumentStatuses>(result);
-    }
+	}
 
-    DocumentStatuses Document::ToFile(String ^ filePath)
-    {
-		if (String::IsNullOrWhiteSpace(filePath)) 
+	DocumentStatuses Document::ToFile(String^ filePath)
+	{
+		if (String::IsNullOrWhiteSpace(filePath))
 			throw gcnew ArgumentNullException("filePath");
 
 		auto result = tidySaveFile(_tidyDoc, Conversions::StringToCharArray(filePath));
 		return static_cast<DocumentStatuses>(result);
-    }
+	}
 
 	uint Document::AccessWarningCount::get()
 	{
 		return tidyAccessWarningCount(_tidyDoc);
 	}
-	
+
 	uint Document::ErrorCount::get()
 	{
 		return tidyErrorCount(_tidyDoc);

--- a/src/Document.hpp
+++ b/src/Document.hpp
@@ -10,10 +10,12 @@
 #include "EntitiesOptions.hpp"
 #include "FeedbackMessage.hpp"
 #include "FileOptions.hpp"
+#include "IncludeInReport.hpp"
 #include "InOutOptions.hpp"
 #include "InputSource.hpp"
 #include "PrettyPrintOptions.hpp"
 #include "RepairOptions.hpp"
+#include "StreamSink.hpp"
 #include "TeachingOptions.hpp"
 #include "TransformationOptions.hpp"
 #include "tidy.h"
@@ -22,7 +24,7 @@ using namespace System::IO;
 
 namespace TidyHtml5Dotnet
 {
-	private delegate Bool FeedbackMessageDelegate(TidyMessage tmessage);
+	private delegate Bool TidyMessageDelegate(TidyMessage tmessage);
 
 	public ref class Document
 	{
@@ -42,16 +44,22 @@ namespace TidyHtml5Dotnet
 		TeachingOptions^ _teachingOptions = nullptr;
 		TransformationOptions^ _transformationOptions = nullptr;
 
+		Int64 _inputLength = 0;
 		InputSource^ _inputSource = nullptr;
 		ctmbstr _contentString;
 
-		FeedbackMessageDelegate^ _feedbackMessageDelegate;
-		Action<FeedbackMessage^>^ _feedbackMessagesCallback = nullptr;
-		Bool FeedbackMessageCallback(TidyMessage tmessage);
+		// Tidy messages (between Tidy and Document)		
+		TidyMessageDelegate^ _tidyMessageDelegate;
+		Bool OnReceiveTidyMessage(TidyMessage tmessage);
 
-		Int64 _inputLength = 0;
+		// Diagnostic messages (between Document and its users)
+		List<FeedbackMessage^>^ _diagnosticMessages = gcnew List<FeedbackMessage^>();
+
+		// Handle Tidy report output
+		StreamSink^ _reportStreamSink = nullptr;
+
 		bool _cleaned = false;
-		bool _disposed = false;		
+		bool _disposed = false;
 
 	public:
 		Document();
@@ -65,18 +73,18 @@ namespace TidyHtml5Dotnet
 		~Document();
 		!Document();
 
-        DocumentStatuses LoadConfig(String ^ filePath, [Optional] Nullable<Encodings> encoding);
-        DocumentStatuses CleanAndRepair();
+		DocumentStatuses LoadConfig(String^ filePath, [Optional] Nullable<Encodings> encoding);
+		DocumentStatuses CleanAndRepair();
 		DocumentStatuses ReportDocType();
 		DocumentStatuses RunDiagnostics();
 		void ErrorSummary();
 		void GeneralInfo();
 
-        property Action<FeedbackMessage^>^ FeedbackMessagesCallback
+		Func<FeedbackMessage^, IncludeInReport>^ OnReceiveDiagnosticMessage;
+		property IReadOnlyList<FeedbackMessage^>^ DiagnosticMessages 
 		{
-			Action<FeedbackMessage^>^ get();
-			void set(Action<FeedbackMessage^>^ value);
-		}
+			IReadOnlyList<FeedbackMessage^>^ get() { return _diagnosticMessages; }
+		};
 
 		virtual String^ ToString() override;
 		DocumentStatuses ToFile(String^ filePath);
@@ -88,16 +96,20 @@ namespace TidyHtml5Dotnet
 
 		IReadOnlyList<OptionDescription^>^ GetOptionDescriptions();
 
-		property CleanupOptions^ CleanupOptions { TidyHtml5Dotnet::CleanupOptions^ get() { return _cleanupOptions; }}
-		property DiagnosticOptions^ DiagnosticOptions { TidyHtml5Dotnet::DiagnosticOptions^ get() { return _diagnosticOptions; }}
-		property DisplayOptions^ DisplayOptions { TidyHtml5Dotnet::DisplayOptions^ get() { return _displayOptions; }}
-		property EncodingOptions^ EncodingOptions { TidyHtml5Dotnet::EncodingOptions^ get() { return _encodingOptions; }}
-		property EntitiesOptions^ EntitiesOptions { TidyHtml5Dotnet::EntitiesOptions^ get() { return _entitiesOptions; }}
-		property FileOptions^ FileOptions { TidyHtml5Dotnet::FileOptions^ get() { return _fileOptions; }}
-		property InOutOptions^ InOutOptions { TidyHtml5Dotnet::InOutOptions^ get() { return _inOutOptions; }}
-		property PrettyPrintOptions^ PrettyPrintOptions { TidyHtml5Dotnet::PrettyPrintOptions^ get() { return _prettyPrintOptions; }}
-		property RepairOptions^ RepairOptions { TidyHtml5Dotnet::RepairOptions^ get() { return _repairOptions; }}
-		property TeachingOptions^ TeachingOptions { TidyHtml5Dotnet::TeachingOptions^ get() { return _teachingOptions; }}
-		property TransformationOptions^ TransformationOptions { TidyHtml5Dotnet::TransformationOptions^ get() { return _transformationOptions; }}
+		// Configuration
+		Document^ WithReportStream(Stream^ stream);
+		Document^ WithReportFile(String^ path);
+
+		property CleanupOptions^ CleanupOptions { TidyHtml5Dotnet::CleanupOptions^ get() { return _cleanupOptions; } }
+		property DiagnosticOptions^ DiagnosticOptions { TidyHtml5Dotnet::DiagnosticOptions^ get() { return _diagnosticOptions; } }
+		property DisplayOptions^ DisplayOptions { TidyHtml5Dotnet::DisplayOptions^ get() { return _displayOptions; } }
+		property EncodingOptions^ EncodingOptions { TidyHtml5Dotnet::EncodingOptions^ get() { return _encodingOptions; } }
+		property EntitiesOptions^ EntitiesOptions { TidyHtml5Dotnet::EntitiesOptions^ get() { return _entitiesOptions; } }
+		property FileOptions^ FileOptions { TidyHtml5Dotnet::FileOptions^ get() { return _fileOptions; } }
+		property InOutOptions^ InOutOptions { TidyHtml5Dotnet::InOutOptions^ get() { return _inOutOptions; } }
+		property PrettyPrintOptions^ PrettyPrintOptions { TidyHtml5Dotnet::PrettyPrintOptions^ get() { return _prettyPrintOptions; } }
+		property RepairOptions^ RepairOptions { TidyHtml5Dotnet::RepairOptions^ get() { return _repairOptions; } }
+		property TeachingOptions^ TeachingOptions { TidyHtml5Dotnet::TeachingOptions^ get() { return _teachingOptions; } }
+		property TransformationOptions^ TransformationOptions { TidyHtml5Dotnet::TransformationOptions^ get() { return _transformationOptions; } }
 	};
 }

--- a/src/IncludeInReport.hpp
+++ b/src/IncludeInReport.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace TidyHtml5Dotnet
+{
+    public enum class IncludeInReport
+    {
+        No,
+        Yes        
+    };
+}

--- a/src/StreamSink.cpp
+++ b/src/StreamSink.cpp
@@ -1,4 +1,4 @@
-#include "OutputSink.hpp"
+#include "StreamSink.hpp"
 
 using namespace System;
 using namespace System::IO;
@@ -8,36 +8,36 @@ namespace TidyHtml5Dotnet
 {
     private delegate void TidyPutByteDelegate(void* sinkData, byte bt);
 
-    OutputSink::OutputSink(Stream ^ stream)
+    StreamSink::StreamSink(Stream ^ stream)
     {
         ArgumentNullException::ThrowIfNull(stream, "stream");
         _stream = stream;
 
-        auto putByteFnPtr = Marshal::GetFunctionPointerForDelegate(gcnew TidyPutByteDelegate(this, &OutputSink::OnPutByte));
+        auto putByteFnPtr = Marshal::GetFunctionPointerForDelegate(gcnew TidyPutByteDelegate(this, &StreamSink::OnPutByte));
 
         _tidyOutputSink = new TidyOutputSink();
         _tidyOutputSink->sinkData = nullptr;
         _tidyOutputSink->putByte = static_cast<TidyPutByteFunc>(putByteFnPtr.ToPointer());        
     }
 
-    OutputSink::~OutputSink()
+    StreamSink::~StreamSink()
     {
         if (_disposed) return;
 
         //Dispose managed objects here
 
-        this->!OutputSink();
+        this->!StreamSink();
         _disposed = true;
     }
 
-    OutputSink::!OutputSink()
+    StreamSink::!StreamSink()
     {
         //Free unmanaged objects here
 
         delete _tidyOutputSink;
     }
 
-    void OutputSink::OnPutByte(void *sinkData, byte bt)
+    void StreamSink::OnPutByte(void *sinkData, byte bt)
     {
         _stream->WriteByte(bt);
     }

--- a/src/StreamSink.hpp
+++ b/src/StreamSink.hpp
@@ -6,12 +6,12 @@ using namespace System::IO;
 
 namespace TidyHtml5Dotnet
 {
-	public ref class OutputSink
+	public ref class StreamSink
 	{
     public:
-		OutputSink(Stream^ stream);
-		~OutputSink();
-		!OutputSink();
+		StreamSink(Stream^ stream);
+		~StreamSink();
+		!StreamSink();
 
 	private:
 		Stream^ _stream;

--- a/src/tidy-html5-dotnet.vcxproj
+++ b/src/tidy-html5-dotnet.vcxproj
@@ -190,7 +190,7 @@
     <ClInclude Include="mappedio.h" />
     <ClInclude Include="message.h" />
     <ClInclude Include="messageobj.h" />
-    <ClInclude Include="OutputSink.hpp" />
+    <ClInclude Include="StreamSink.hpp" />
     <ClInclude Include="TeachingOptions.hpp" />
     <ClInclude Include="Tidy.hpp" />
     <ClInclude Include="TidyException.hpp" />
@@ -316,7 +316,7 @@
       <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</CompileAsManaged>
       <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</CompileAsManaged>
     </ClCompile>
-    <ClCompile Include="OutputSink.cpp" />
+    <ClCompile Include="StreamSink.cpp" />
     <ClCompile Include="parser.c">
       <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</CompileAsManaged>
       <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</CompileAsManaged>
@@ -385,6 +385,7 @@
   <ItemGroup>
     <None Include=".gitignore" />
     <None Include="CPP.HINT" />
+    <None Include="IncludeInReport.hpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets" />

--- a/src/tidy-html5-dotnet.vcxproj.filters
+++ b/src/tidy-html5-dotnet.vcxproj.filters
@@ -194,7 +194,7 @@
     <ClInclude Include="FeedbackMessage.hpp">
       <Filter>dotnet Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="OutputSink.hpp">
+    <ClInclude Include="StreamSink.hpp">
       <Filter>dotnet Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Tidy.hpp">
@@ -307,7 +307,7 @@
     <ClCompile Include="InputSource.cpp">
       <Filter>dotnet Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="OutputSink.cpp">
+    <ClCompile Include="StreamSink.cpp">
       <Filter>dotnet Source Files</Filter>
     </ClCompile>
     <ClCompile Include="FeedbackMessage.cpp">
@@ -330,6 +330,9 @@
   <ItemGroup>
     <None Include=".gitignore" />
     <None Include="CPP.HINT">
+      <Filter>dotnet Header Files</Filter>
+    </None>
+    <None Include="IncludeInReport.hpp">
       <Filter>dotnet Header Files</Filter>
     </None>
   </ItemGroup>

--- a/tidy-html5-dotnet.tests/AccessibilitySnapshotTests.cs
+++ b/tidy-html5-dotnet.tests/AccessibilitySnapshotTests.cs
@@ -1,55 +1,23 @@
-﻿using System.Diagnostics;
+﻿using System.Text;
 using tidy_html5_dotnet_test.helpers;
 using TidyHtml5Dotnet;
-using Xunit.Abstractions;
 
 namespace tidy_html5_dotnet_test;
 
 [Collection("Accessibility")]
-public class AccessibilitySnapshotTests(ITestOutputHelper output)
+public class AccessibilitySnapshotTests()
 {
-    private readonly ITestOutputHelper _output = output;
-
     [Theory]
     [DirectoryCasesData("access")] // scans cases/access-cases + cases/access-expects
     public void Accessibility_Case(CaseData testCaseData)
     {
         // Build document from input string
-        var doc = Document.FromFile(testCaseData.InputHtml);
-
-        // Capture messages
-        var receivedMessages = new List<string>();
-        doc.FeedbackMessagesCallback = message =>
-        {
-            if(message.Level == ReportLevel.Info || message.Level == ReportLevel.DialogueInfo)
-                return;
-
-            //if (message.Key == "STRING_HELLO_ACCESS") 
-              // return;
-
-            var output = message.Output?.Trim();
-
-            if (string.IsNullOrWhiteSpace(output))
-                return;
-
-            // Split on CRLF or LF, remove empty entries, and trim each line
-            var lines = output.Split(["\r\n", "\n"], StringSplitOptions.None);
-
-            foreach (var line in lines)
-            {
-                var trimmed = line.Trim();
-                if (!string.IsNullOrWhiteSpace(trimmed))
-                    receivedMessages.Add(trimmed);
-            }
-        };
+        var reportStream = new MemoryStream();
+        var doc = Document.FromFile(testCaseData.InputHtml).WithReportStream(reportStream);       
 
         // Load config text (if API supports from string; if not, parse/apply options)
         var configStatus = doc.LoadConfig(testCaseData.ConfigFile);
         Assert.Equal(DocumentStatuses.Success, configStatus);
-        
-        //TODO: these filters do not affect the message callback. They work on the Error Sink
-        //doc.DisplayOptions.Quiet = true;
-        //doc.DisplayOptions.ShowInfo = false;
 
         // Clean & repair
         var cleanStatus = doc.CleanAndRepair();
@@ -59,7 +27,9 @@ public class AccessibilitySnapshotTests(ITestOutputHelper output)
         var receivedContent = doc.ToString();
         Assert.Equal(testCaseData.ExpectedContent, receivedContent);
 
-        // Compare messages
-        Assert.Equal(testCaseData.ExpectedMessages, receivedMessages);
+        // Compare report
+        reportStream.Position = 0;
+        using var reader = new StreamReader(reportStream, Encoding.UTF8, leaveOpen: false);
+        Assert.Equal(testCaseData.ExpectedReport, reader.ReadToEnd());
     }
 }

--- a/tidy-html5-dotnet.tests/DiagnosticMessageTests.cs
+++ b/tidy-html5-dotnet.tests/DiagnosticMessageTests.cs
@@ -3,19 +3,12 @@ using Xunit.Abstractions;
 
 namespace tidy_html5_dotnet_test;
 
-public class FeedbackMessageTests
+public class DiagnosticMessageTests(ITestOutputHelper output)
 {
-    private readonly ITestOutputHelper _output;
-    private readonly List<FeedbackMessage> _tidyMessages = [];
-
-    public FeedbackMessageTests(ITestOutputHelper output)
-    {
-        _output = output;
-        _tidyMessages.Clear();
-    }
+    private readonly ITestOutputHelper _output = output;
 
     [Fact]
-    public void FeedbackMessages_With_String_Arguments()
+    public void Document_CleanAndRepair_ReturnsDiagnosticMessages()
     {
         string htmlString = @"<!DOCTYPE HTML PUBLIC ""-//W3C//DTD HTML 4.01//EN"" ""http://www.w3.org/TR/html4/strict.dtd""><html><head><title>Issue #378</title><meta http-equiv=""Content-type"" content=""text/html; charset=utf-8""></head><body><p><a href=""http://example.com/é"">foo</a></p></body></html>";
 
@@ -23,16 +16,15 @@ public class FeedbackMessageTests
         Assert.NotNull(tidyDocument);
 
         tidyDocument.RepairOptions.StrictTagsAttributes = true;
-        tidyDocument.FeedbackMessagesCallback = message => _tidyMessages.Add(message);
 
         var status = tidyDocument.CleanAndRepair();
         Assert.Equal(DocumentStatuses.Warnings, status);
 
-        foreach (var message in _tidyMessages)
+        foreach (var message in tidyDocument.DiagnosticMessages)
         {
             _output.WriteLine(message.ToString());
         }
 
-        Assert.Equal(8, _tidyMessages.Count);
+        Assert.Equal(8, tidyDocument.DiagnosticMessages.Count);
     }
 }

--- a/tidy-html5-dotnet.tests/DocumentCleanAndRepairTests.cs
+++ b/tidy-html5-dotnet.tests/DocumentCleanAndRepairTests.cs
@@ -4,16 +4,9 @@ using Xunit.Abstractions;
 
 namespace tidy_html5_dotnet_test;
 
-public class DocumentCleanAndRepairTests
+public class DocumentCleanAndRepairTests(ITestOutputHelper output)
 {
-    private readonly ITestOutputHelper _output;
-    private readonly List<FeedbackMessage> _tidyMessages = [];
-
-    public DocumentCleanAndRepairTests(ITestOutputHelper output)
-    {
-        _output = output;
-        _tidyMessages.Clear();
-    }
+    private readonly ITestOutputHelper _output = output;
 
     [Fact]
     public void CleanAndRepair_Document_without_parameters_must_succeed()
@@ -21,12 +14,16 @@ public class DocumentCleanAndRepairTests
         using var tidyDocument = new Document();
         Assert.NotNull(tidyDocument);
 
-        tidyDocument.FeedbackMessagesCallback = message => _tidyMessages.Add(message);
+        tidyDocument.OnReceiveDiagnosticMessage =
+            message => (message.Level == ReportLevel.Info ||
+                        message.Level == ReportLevel.DialogueInfo)
+                ? IncludeInReport.No
+                : IncludeInReport.Yes;
 
         var status = tidyDocument.CleanAndRepair();
         Assert.Equal(DocumentStatuses.Success, status);
 
-        Assert.Empty(_tidyMessages);
+        Assert.Empty(tidyDocument.DiagnosticMessages);
     }
 
     [Fact]
@@ -36,17 +33,15 @@ public class DocumentCleanAndRepairTests
         using var tidyDocument = new Document(htmlString);
         Assert.NotNull(tidyDocument);
 
-        tidyDocument.FeedbackMessagesCallback = message => _tidyMessages.Add(message);
-
         var status = tidyDocument.CleanAndRepair();
         Assert.Equal(DocumentStatuses.Warnings, status);
 
-        foreach (var message in _tidyMessages)
+        foreach (var message in tidyDocument.DiagnosticMessages)
         {
             _output.WriteLine(message.ToString());
         }
 
-        Assert.Equal(4, _tidyMessages.Count);
+        Assert.Equal(4, tidyDocument.DiagnosticMessages.Count);
     }
 
     [Fact]
@@ -56,16 +51,14 @@ public class DocumentCleanAndRepairTests
         using var tidyDocument = new Document(htmlStream);
         Assert.NotNull(tidyDocument);
 
-        tidyDocument.FeedbackMessagesCallback = message => _tidyMessages.Add(message);
-
         var status = tidyDocument.CleanAndRepair();
         Assert.Equal(DocumentStatuses.Warnings, status);
 
-        foreach (var message in _tidyMessages)
+        foreach (var message in tidyDocument.DiagnosticMessages)
         {
             _output.WriteLine(message.ToString());
         }
 
-        Assert.Equal(4, _tidyMessages.Count);
+        Assert.Equal(4, tidyDocument.DiagnosticMessages.Count);
     }
 }

--- a/tidy-html5-dotnet.tests/DocumentCountersTests.cs
+++ b/tidy-html5-dotnet.tests/DocumentCountersTests.cs
@@ -1,17 +1,19 @@
-﻿using TidyHtml5Dotnet;
+﻿using System.Text;
+using TidyHtml5Dotnet;
 using Xunit.Abstractions;
 
 namespace tidy_html5_dotnet_test;
 
-public class DocumentCountersTests
+public class DocumentCountersTests(ITestOutputHelper output)
 {
-    private readonly ITestOutputHelper _output;
-    private readonly List<FeedbackMessage> _tidyMessages = [];
+    private readonly ITestOutputHelper _output = output;
 
-    public DocumentCountersTests(ITestOutputHelper output)
+    private static IncludeInReport ExcludeInfoMessages(FeedbackMessage message)
     {
-        _output = output;
-        _tidyMessages.Clear();
+        return (message.Level == ReportLevel.Info ||
+                message.Level == ReportLevel.DialogueInfo)
+            ? IncludeInReport.No
+            : IncludeInReport.Yes;
     }
 
     [Fact]
@@ -22,12 +24,7 @@ public class DocumentCountersTests
         using var tidyDocument = new Document(htmlString);       
         Assert.NotNull(tidyDocument);
 
-        tidyDocument.FeedbackMessagesCallback = message =>
-        {
-            if (message.Level == ReportLevel.Info || message.Level == ReportLevel.DialogueInfo)
-                return;
-            _tidyMessages.Add(message);
-        };
+        tidyDocument.OnReceiveDiagnosticMessage = ExcludeInfoMessages;
 
         // Act
         var status = tidyDocument.CleanAndRepair();
@@ -37,17 +34,17 @@ public class DocumentCountersTests
 
         _output.WriteLine(tidyDocument.ToString());
 
-        foreach (var message in _tidyMessages)
+        foreach (var message in tidyDocument.DiagnosticMessages)
         {
             _output.WriteLine($"{message.Level}: {message}");
         }
 
-        Assert.Single(_tidyMessages);
+        Assert.Single(tidyDocument.DiagnosticMessages);
         Assert.Equal(0u, tidyDocument.ErrorCount);
         Assert.Equal(0u, tidyDocument.WarningCount);
         Assert.Equal(0u, tidyDocument.AccessWarningCount);
 
-        var dialogueSummary = _tidyMessages.Single(m => m.Key == "STRING_NO_ERRORS").Output;
+        var dialogueSummary = tidyDocument.DiagnosticMessages.Single(m => m.Key == "STRING_NO_ERRORS").Output;
         Assert.Equal("No warnings or errors were found.", dialogueSummary);
     }
 
@@ -59,12 +56,7 @@ public class DocumentCountersTests
         using var tidyDocument = new Document(htmlString);       
         Assert.NotNull(tidyDocument);
 
-        tidyDocument.FeedbackMessagesCallback = message =>
-        {
-            if (message.Level == ReportLevel.Info || message.Level == ReportLevel.DialogueInfo)
-                return;
-            _tidyMessages.Add(message);
-        };
+        tidyDocument.OnReceiveDiagnosticMessage = ExcludeInfoMessages;
 
         // Act
         var status = tidyDocument.CleanAndRepair();
@@ -74,17 +66,17 @@ public class DocumentCountersTests
 
         _output.WriteLine(tidyDocument.ToString());
 
-        foreach (var message in _tidyMessages)
+        foreach (var message in tidyDocument.DiagnosticMessages)
         {
             _output.WriteLine($"{message.Level}: {message}");
         }
 
-        Assert.Equal(3, _tidyMessages.Count);
+        Assert.Equal(3, tidyDocument.DiagnosticMessages.Count);
         Assert.Equal(0u, tidyDocument.ErrorCount);
         Assert.Equal(2u, tidyDocument.WarningCount);
         Assert.Equal(0u, tidyDocument.AccessWarningCount);
 
-        var dialogueSummary = _tidyMessages.Single(m => m.Key == "STRING_ERROR_COUNT").Output;
+        var dialogueSummary = tidyDocument.DiagnosticMessages.Single(m => m.Key == "STRING_ERROR_COUNT").Output;
         Assert.Equal("Tidy found 2 warnings and 0 errors!", dialogueSummary);
     }
 
@@ -96,12 +88,7 @@ public class DocumentCountersTests
         using var tidyDocument = new Document(htmlString);       
         Assert.NotNull(tidyDocument);
 
-        tidyDocument.FeedbackMessagesCallback = message =>
-        {
-            if (message.Level == ReportLevel.Info || message.Level == ReportLevel.DialogueInfo)
-                return;
-            _tidyMessages.Add(message);
-        };
+        tidyDocument.OnReceiveDiagnosticMessage = ExcludeInfoMessages;
 
         // Act
         var status = tidyDocument.CleanAndRepair();
@@ -110,17 +97,19 @@ public class DocumentCountersTests
         Assert.Equal(DocumentStatuses.Errors, status);
         _output.WriteLine(tidyDocument.ToString());
 
-        foreach (var message in _tidyMessages)
+        foreach (var message in tidyDocument.DiagnosticMessages)
         {
-            _output.WriteLine($"{message.Level}: {message}" );
+            _output.WriteLine($"{message.Level}: {message}");
         }
 
-        Assert.Equal(9, _tidyMessages.Count);
+        Assert.Equal(9, tidyDocument.DiagnosticMessages.Count);
         Assert.Equal(1u, tidyDocument.ErrorCount);
         Assert.Equal(6u, tidyDocument.WarningCount);
         Assert.Equal(0u, tidyDocument.AccessWarningCount);
 
-        var dialogueSummary = _tidyMessages.Single(m => m.Key == "STRING_ERROR_COUNT").Output;
+        Assert.NotEmpty(tidyDocument.DiagnosticMessages);
+
+        var dialogueSummary = tidyDocument.DiagnosticMessages.Single(m => m.Key == "STRING_ERROR_COUNT").Output;
         Assert.Equal("Tidy found 6 warnings and 1 error!", dialogueSummary);
     }
 
@@ -132,12 +121,7 @@ public class DocumentCountersTests
         using var tidyDocument = new Document(htmlString);       
         Assert.NotNull(tidyDocument);
 
-        tidyDocument.FeedbackMessagesCallback = message =>
-        {
-            if (message.Level == ReportLevel.Info || message.Level == ReportLevel.DialogueInfo)
-                return;
-            _tidyMessages.Add(message);
-        };
+        tidyDocument.OnReceiveDiagnosticMessage = ExcludeInfoMessages;
 
         // Act
         tidyDocument.DiagnosticOptions.AccessibilityCheckLevel = AccessibilityCheckLevels.TidyClassic;
@@ -148,17 +132,17 @@ public class DocumentCountersTests
 
         _output.WriteLine(tidyDocument.ToString());
 
-        foreach (var message in _tidyMessages)
+        foreach (var message in tidyDocument.DiagnosticMessages)
         {
-            _output.WriteLine($"{message.Level}: {message}" );
+            _output.WriteLine($"{message.Level}: {message}");
         }
 
-        Assert.Equal(4, _tidyMessages.Count);
+        Assert.Equal(4, tidyDocument.DiagnosticMessages.Count);
         Assert.Equal(0u, tidyDocument.ErrorCount);
         Assert.Equal(1u, tidyDocument.WarningCount);
         Assert.Equal(0u, tidyDocument.AccessWarningCount);
 
-        var dialogueSummary = _tidyMessages.Single(m => m.Key == "STRING_ERROR_COUNT").Output;
+        var dialogueSummary = tidyDocument.DiagnosticMessages.Single(m => m.Key == "STRING_ERROR_COUNT").Output;
         Assert.Equal("Tidy found 1 warning and 0 errors!", dialogueSummary);
     }
 
@@ -166,16 +150,12 @@ public class DocumentCountersTests
     public void AccessWarningCounter_should_be_non_zero_on_checklevel_priority3()
     {
         // Arrange
+        var reportStream = new MemoryStream();
         var htmlString = "<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 3.2//EN\">\r\n<html><head><title>Title</title></head>\r\n<body>\r\n\r\n<p><img src=\"img.png\"></p>\r\n\r\n</body></html>";
-        using var tidyDocument = new Document(htmlString);
+        using var tidyDocument = new Document(htmlString).WithReportStream(reportStream);
         Assert.NotNull(tidyDocument);
 
-        tidyDocument.FeedbackMessagesCallback = message =>
-        {
-            if (message.Level == ReportLevel.Info || message.Level == ReportLevel.DialogueInfo)
-                return;
-            _tidyMessages.Add(message);
-        };
+        tidyDocument.OnReceiveDiagnosticMessage = ExcludeInfoMessages;
 
         // Act
         tidyDocument.DiagnosticOptions.AccessibilityCheckLevel = AccessibilityCheckLevels.Priority3;
@@ -183,20 +163,22 @@ public class DocumentCountersTests
 
         // Assert
         Assert.Equal(DocumentStatuses.Warnings, status);
+        var output = tidyDocument.ToString();
+        Assert.NotEmpty(output);
+        _output.WriteLine(output);
 
-        _output.WriteLine(tidyDocument.ToString());
-
-        foreach (var message in _tidyMessages)
+        Assert.NotEmpty(tidyDocument.DiagnosticMessages);
+        foreach (var message in tidyDocument.DiagnosticMessages)
         {
             _output.WriteLine($"{message.Level}: {message}");
         }
 
-        Assert.Equal(7, _tidyMessages.Count);
+        Assert.Equal(7, tidyDocument.DiagnosticMessages.Count);
         Assert.Equal(0u, tidyDocument.ErrorCount);
         Assert.Equal(0u, tidyDocument.WarningCount); // warning count moved to access warning counter
         Assert.Equal(6u, tidyDocument.AccessWarningCount);
 
-        var dialogueSummary = _tidyMessages.Single(m => m.Key == "STRING_NO_ERRORS").Output;
+        var dialogueSummary = tidyDocument.DiagnosticMessages.Single(m => m.Key == "STRING_NO_ERRORS").Output;
         Assert.Equal("No warnings or errors were found.", dialogueSummary);
     }
 }

--- a/tidy-html5-dotnet.tests/helpers/CaseData.cs
+++ b/tidy-html5-dotnet.tests/helpers/CaseData.cs
@@ -7,7 +7,7 @@ public sealed record CaseData(
     string InputHtml,
     string ConfigFile,
     string ExpectedContent,
-    IReadOnlyList<string> ExpectedMessages,
+    string ExpectedReport,
     DocumentStatuses CleanupStatus,
     DocumentStatuses DiagnosticStatus)
 {

--- a/tidy-html5-dotnet.tests/helpers/DirectoryCasesDataAttribute.cs
+++ b/tidy-html5-dotnet.tests/helpers/DirectoryCasesDataAttribute.cs
@@ -34,7 +34,6 @@ public sealed class DirectoryCasesDataAttribute : DataAttribute
             var fileName = Path.GetFileName(inputFilePath); 
             
             // Must contain @
-            // TODO: check if the 0,1,2 after the @ have a meaning
             var atIndex = fileName.IndexOf('@');
             if (atIndex < 0) continue;
 
@@ -61,13 +60,11 @@ public sealed class DirectoryCasesDataAttribute : DataAttribute
                 continue; // skip only if both are missing
 
             var expectedContent = File.ReadAllText(expectedContentFile);
-            var expectedMessages = File.ReadAllLines(expectedMessagesFile)
-                .Where(l => !string.IsNullOrWhiteSpace(l))
-                .Select(l => l.Trim())
-                .ToList()
-                .AsReadOnly();
+            var expectedReport = File.ReadAllText(expectedMessagesFile);
 
-            var cleanupStatus = expectedMessages.Count > 1 ? DocumentStatuses.Warnings : DocumentStatuses.Success;
+            var cleanupStatus = "No warnings or errors were found.".Equals(expectedReport.Trim())
+                ? DocumentStatuses.Success
+                : DocumentStatuses.Warnings;
 
             yield return new object[]
             {
@@ -76,7 +73,7 @@ public sealed class DirectoryCasesDataAttribute : DataAttribute
                     inputFilePath,
                     configFilePath,
                     expectedContent,
-                    expectedMessages,
+                    expectedReport,
                     cleanupStatus,
                     cleanupStatus
                 )


### PR DESCRIPTION
Diagnostic messages are always sent. Users can inspect them and decide if they need to be sent to the report. The report is captured from the TidyErrorSink